### PR TITLE
chore: update Traefik from v3.0 to v3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,7 @@
 ## 1.0.1
 
 - Fixed postgres image version to 17
+
+## 1.0.2
+
+- Updated Traefik from v3.0 to v3.6.2 for Docker API compatibility

--- a/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
+++ b/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
@@ -1,7 +1,7 @@
 services:
   traefik:
     restart: on-failure
-    image: traefik:v3.0
+    image: traefik:v3.6.2
     command:
       - "--api.insecure=true"
       - "--providers.docker=true"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serverpod_vps
 description: A CLI tool for generating the required files for a Serverpod VPS deployment
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/inf0rmatix/serverpod_vps
 homepage: https://github.com/inf0rmatix/serverpod_vps
 documentation: https://github.com/inf0rmatix/serverpod_vps


### PR DESCRIPTION
## Summary

- Updates Traefik image from v3.0 to v3.6.2 in docker-compose.production.yaml
- Fixes Docker API compatibility issue where Traefik v3.0 uses API version 1.24, but newer Docker versions require at least version 1.44
- Bumps package version to 1.0.2

## Test plan

- [x] Verify docker-compose.production.yaml generates correctly with `serverpod_vps upgrade`
- [x] Test deployment with the updated Traefik version on a VPS with recent Docker