### PR TITLE
Pass IdP JWT password secrets via compose and GitHub Actions — closes #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- markdownlint-disable first-line-heading -->
 
+## 1.0.4
+
+- Pass IdP/JWT password keys via `SERVERPOD_PASSWORD_*` in generated `docker-compose.production.yaml` and GitHub Actions deploy env (for `serverpod_auth_idp_server` + `JwtConfigFromPasswords()`)
+- Document corresponding repository secrets in the deployment guide
+
 ## 1.0.3
 
 - Updated documentation

--- a/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.md
+++ b/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.md
@@ -281,6 +281,13 @@ The following secrets configure Serverpod and the database:
 | SERVERPOD_WEB_SERVER_PUBLIC_HOST      | The domain for the Web server (e.g., web.my-domain.com)                                                     |
 | SERVERPOD_INSIGHTS_SERVER_PUBLIC_HOST | The domain for the Insights server (e.g., insights.my-domain.com)                                           |
 | SERVERPOD_SERVICE_SECRET              | The same value as in your local `passwords.yaml` file, required to connect using the Serverpod Insights app |
+| SERVERPOD_PASSWORD_EMAIL_SECRET_HASH_PEPPER     | Same value as the `emailSecretHashPepper` key in your local `passwords.yaml` (production) — required when using `serverpod_auth_idp_server` with `JwtConfigFromPasswords()` |
+| SERVERPOD_PASSWORD_JWT_HMAC_SHA512_PRIVATE_KEY  | Same value as the `jwtHmacSha512PrivateKey` key in your local `passwords.yaml` (production) — required when using IdP JWT from passwords |
+| SERVERPOD_PASSWORD_JWT_REFRESH_TOKEN_HASH_PEPPER | Same value as the `jwtRefreshTokenHashPepper` key in your local `passwords.yaml` (production) — required when using IdP JWT from passwords |
+
+The production Docker image does not ship `passwords.yaml`. Serverpod reads secret values from environment variables named `SERVERPOD_PASSWORD_<key>`, where `<key>` matches the camelCase key from `passwords.yaml` (for example, `SERVERPOD_PASSWORD_jwtRefreshTokenHashPepper`). The generated workflow and `docker-compose.production.yaml` pass the three IdP/JWT-related keys above from GitHub Actions into the container.
+
+If you use `JwtConfigFromPasswords()` or extend IdP configuration with additional password keys, add each key the same way: declare it under the `serverpod` service `environment` in `docker-compose.production.yaml`, map a repository secret in `.github/workflows/deployment-docker.yml`, and document the secret here. Projects without `serverpod_auth_idp_server` / `JwtConfigFromPasswords()` do not need the three `SERVERPOD_PASSWORD_*` repository secrets unless your app references those password keys at runtime.
 
 ## Creating the deployment files
 

--- a/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.yml
+++ b/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.yml
@@ -164,6 +164,11 @@ jobs:
           SERVERPOD_MAX_REQUEST_SIZE: ${{ secrets.SERVERPOD_MAX_REQUEST_SIZE }}
           # The token used to connect with insights must be at least 20 chars
           SERVERPOD_SERVICE_SECRET: ${{ secrets.SERVERPOD_SERVICE_SECRET }}
+          # IdP / JWT (serverpod_auth_idp_server + JwtConfigFromPasswords):
+          # copy values from the same keys in local passwords.yaml (production)
+          SERVERPOD_PASSWORD_emailSecretHashPepper: ${{ secrets.SERVERPOD_PASSWORD_EMAIL_SECRET_HASH_PEPPER }}
+          SERVERPOD_PASSWORD_jwtHmacSha512PrivateKey: ${{ secrets.SERVERPOD_PASSWORD_JWT_HMAC_SHA512_PRIVATE_KEY }}
+          SERVERPOD_PASSWORD_jwtRefreshTokenHashPepper: ${{ secrets.SERVERPOD_PASSWORD_JWT_REFRESH_TOKEN_HASH_PEPPER }}
 
       - name: cleanup
         run: rm -rf ~/.ssh

--- a/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
+++ b/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
@@ -69,6 +69,9 @@ services:
       - SERVERPOD_WEB_SERVER_PUBLIC_SCHEME
       - SERVERPOD_WEB_SERVER_PORT
       - SERVERPOD_SERVICE_SECRET
+      - SERVERPOD_PASSWORD_emailSecretHashPepper
+      - SERVERPOD_PASSWORD_jwtHmacSha512PrivateKey
+      - SERVERPOD_PASSWORD_jwtRefreshTokenHashPepper
       - SERVERPOD_MAX_REQUEST_SIZE
     command:
       [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serverpod_vps
 description: A CLI tool for generating the required files for a Serverpod VPS deployment
-version: 1.0.3
+version: 1.0.4
 repository: https://github.com/inf0rmatix/serverpod_vps
 homepage: https://github.com/inf0rmatix/serverpod_vps
 documentation: https://github.com/inf0rmatix/serverpod_vps


### PR DESCRIPTION
## Summary
Extends the generated VPS scaffold so Serverpod apps using `serverpod_auth_idp_server` with `JwtConfigFromPasswords()` receive `SERVERPOD_PASSWORD_*` values at runtime, without relying on `passwords.yaml` in the container.

Refs / closes inf0rmatix/serverpod_vps#9

## Changes
- **`docker-compose.production.yaml`**: pass through `SERVERPOD_PASSWORD_emailSecretHashPepper`, `SERVERPOD_PASSWORD_jwtHmacSha512PrivateKey`, `SERVERPOD_PASSWORD_jwtRefreshTokenHashPepper`.
- **`deployment-docker.yml`**: map deploy-step env vars to GitHub repository secrets (`SERVERPOD_PASSWORD_EMAIL_SECRET_HASH_PEPPER`, etc.).
- **`deployment-docker.md`**: document new secrets and the `SERVERPOD_PASSWORD_<key>` pattern for future keys.
- **CHANGELOG** / **version**: `1.0.4`.