### PR TITLE
feat: Node 24 GitHub Actions, linux/arm64, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Analyze
+        run: dart analyze --fatal-warnings
+
+      - name: Run tests
+        run: dart test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- markdownlint-disable first-line-heading -->
 
+## 1.0.5
+
+- Bump generated GitHub Actions to Node 24-compatible versions (`checkout@v6`, `login-action@v4`, `metadata-action@v6`, `setup-buildx-action@v4`, `build-push-action@v7`)
+- Build Docker images for `linux/arm64` only (64-bit ARM VPS, e.g. Hetzner Cloud)
+
 ## 1.0.4
 
 - Pass IdP/JWT password keys via `SERVERPOD_PASSWORD_*` in generated `docker-compose.production.yaml` and GitHub Actions deploy env (for `serverpod_auth_idp_server` + `JwtConfigFromPasswords()`)

--- a/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.yml
+++ b/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.yml
@@ -32,10 +32,10 @@ jobs:
         working-directory: ./projectname_server
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,15 +43,15 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             GITHUB_PAT=${{ secrets.PAT_GITHUB }}
@@ -65,7 +65,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # This determines which hardware platforms the image will run on
           # further details: https://docs.docker.com/build/building/multi-platform/
-          platforms: linux/arm/v7, linux/arm64/v8
+          platforms: linux/arm64
 
   deploy:
     needs: build-and-push-image
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install ssh keys
         run: |
@@ -90,7 +90,7 @@ jobs:
         run: ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_rsa ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "echo SSH connection successful"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serverpod_vps
 description: A CLI tool for generating the required files for a Serverpod VPS deployment
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/inf0rmatix/serverpod_vps
 homepage: https://github.com/inf0rmatix/serverpod_vps
 documentation: https://github.com/inf0rmatix/serverpod_vps

--- a/test/template_generator_test.dart
+++ b/test/template_generator_test.dart
@@ -88,6 +88,53 @@ void main() {
     });
 
     test(
+      'replaces projectname and email placeholders in generated files',
+      () async {
+        const testDirName = 'placeholder_test_project';
+        const testEmail = 'ssl@example.com';
+
+        final testDir = Directory(path.join(tempDir.path, testDirName))
+          ..createSync();
+
+        Directory(path.join(testDir.path, '${testDirName}_server'))
+            .createSync();
+        Directory(path.join(testDir.path, '${testDirName}_client'))
+            .createSync();
+
+        final originalDir = Directory.current;
+        Directory.current = testDir.path;
+
+        try {
+          await generator.generateDeploymentFilesForTesting(email: testEmail);
+
+          final composeContent = File(
+            path.join(
+              testDir.path,
+              '${testDirName}_server',
+              'docker-compose.production.yaml',
+            ),
+          ).readAsStringSync();
+
+          final workflowContent = File(
+            path.join(
+              testDir.path,
+              '.github',
+              'workflows',
+              'deployment-docker.yml',
+            ),
+          ).readAsStringSync();
+
+          expect(composeContent, isNot(contains('projectname')));
+          expect(workflowContent, isNot(contains('projectname')));
+          expect(workflowContent, contains('${testDirName}_server'));
+          expect(composeContent, contains(testEmail));
+        } finally {
+          Directory.current = originalDir;
+        }
+      },
+    );
+
+    test(
       'includes IdP JWT password env vars in generated deployment files',
       () async {
         const testDirName = 'password_env_test_project';
@@ -144,10 +191,6 @@ void main() {
           for (final secret in githubSecrets) {
             expect(workflowContent, contains(secret));
           }
-
-          expect(composeContent, isNot(contains('projectname')));
-          expect(workflowContent, contains('${testDirName}_server'));
-          expect(composeContent, contains(testEmail));
         } finally {
           Directory.current = originalDir;
         }
@@ -274,6 +317,29 @@ void main() {
           Directory.current = originalDir;
         }
       });
+    });
+  });
+
+  group('deployment workflow template', () {
+    late String workflowTemplate;
+
+    setUp(() {
+      workflowTemplate = File(
+        path.join(
+          Directory.current.path,
+          'lib',
+          'assets',
+          'templates',
+          'serverpod_templates',
+          'github',
+          'workflows',
+          'deployment-docker.yml',
+        ),
+      ).readAsStringSync();
+    });
+
+    test('builds Docker image for linux/arm64', () {
+      expect(workflowTemplate, contains('platforms: linux/arm64'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- Bump generated `deployment-docker.yml` to Node 24-compatible action majors (`checkout@v6`, `login-action@v4`, `metadata-action@v6`, `setup-buildx-action@v4`, `build-push-action@v7`)
- Build Docker images for `linux/arm64` only (aligned with production ARM VPS usage)
- Add repository CI workflow running `dart analyze` and `dart test` on pull requests and pushes to `main`
- Extend template generator tests for placeholder replacement and `linux/arm64` platform

Closes #10

## Test plan
- [x] `dart analyze --fatal-warnings`
- [x] `dart test` (10 tests)
- [ ] CI workflow passes on this PR