### PR TITLE
feat: project-specific sanitized Docker network names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 <!-- markdownlint-disable first-line-heading -->
 
+## 1.0.6
+
+- Use a project-specific Docker network name via the `{{DOCKER_NETWORK_NAME}}` placeholder in generated `docker-compose.production.yaml` instead of the hardcoded `serverpod-network`
+- Sanitize project names so generated Docker network names only contain valid characters
+- Inform when the Docker network name is sanitized or truncated to fit Docker limits
+- **Note:** Existing deployments must update `docker-compose.production.yaml` to use the new network name or re-run `serverpod_vps` to regenerate the file
+
 ## 1.0.5
 
 - Bump generated GitHub Actions to Node 24-compatible versions (`checkout@v6`, `login-action@v4`, `metadata-action@v6`, `setup-buildx-action@v4`, `build-push-action@v7`)

--- a/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
+++ b/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
@@ -20,7 +20,7 @@ services:
       - postgres
       - serverpod
     networks:
-      - serverpod-network
+      - "{{DOCKER_NETWORK_NAME}}"
 
   postgres:
     healthcheck:
@@ -43,7 +43,7 @@ services:
     volumes:
       - projectname_data:/var/lib/postgresql/data
     networks:
-      - serverpod-network
+      - "{{DOCKER_NETWORK_NAME}}"
 
   serverpod:
     restart: on-failure
@@ -108,11 +108,11 @@ services:
       postgres:
         condition: service_healthy
     networks:
-      - serverpod-network
+      - "{{DOCKER_NETWORK_NAME}}"
 
 networks:
-  serverpod-network:
-    name: serverpod-network
+  "{{DOCKER_NETWORK_NAME}}":
+    name: "{{DOCKER_NETWORK_NAME}}"
     driver: bridge
 
 volumes:

--- a/lib/serverpod_vps.dart
+++ b/lib/serverpod_vps.dart
@@ -1,1 +1,2 @@
+export 'src/docker_network_name.dart';
 export 'src/template_generator.dart';

--- a/lib/src/docker_network_name.dart
+++ b/lib/src/docker_network_name.dart
@@ -1,0 +1,93 @@
+/// Result of building a Docker network name from a project directory name.
+typedef DockerNetworkNameBuildResult = ({
+  String networkName,
+  bool wasSanitized,
+  bool wasTruncated,
+});
+
+/// Sanitizes and validates Docker Compose network names for generated VPS files.
+class DockerNetworkName {
+  const DockerNetworkName._();
+
+  /// Docker user-defined network names must start with a letter or digit and may
+  /// only contain letters, digits, hyphens, underscores, and periods.
+  static final RegExp _namePattern = RegExp(r'^[a-zA-Z0-9][a-zA-Z0-9_.-]*$');
+
+  /// Docker Engine rejects names longer than 63 characters (`name must be 63
+  /// characters or fewer`) because network names are used as DNS labels; see
+  /// RFC 1035 section 2.3.4 and https://github.com/moby/moby/issues/36487
+  static const int _maxLength = 63;
+  static const String _suffix = '-network';
+  static const String _fallbackPrefix = 'serverpod';
+
+  /// Builds a Docker-compatible network name from a project directory name.
+  static String fromProjectName(String projectName) {
+    return buildFromProjectName(projectName).networkName;
+  }
+
+  /// Builds a Docker-compatible network name and reports whether it was adjusted.
+  static DockerNetworkNameBuildResult buildFromProjectName(String projectName) {
+    final sanitizedBaseName = _sanitizeBaseName(projectName);
+    final wasSanitized = sanitizedBaseName != projectName;
+    final networkNameBeforeTruncation = '$sanitizedBaseName$_suffix';
+    final wasTruncated = networkNameBeforeTruncation.length > _maxLength;
+
+    final networkName = wasTruncated
+        ? _truncateNetworkName(sanitizedBaseName)
+        : networkNameBeforeTruncation;
+
+    return (
+      networkName: networkName,
+      wasSanitized: wasSanitized,
+      wasTruncated: wasTruncated,
+    );
+  }
+
+  /// Whether [networkName] is valid for Docker Compose `networks.<name>.name`.
+  static bool isValid(String networkName) {
+    if (networkName.isEmpty || networkName.length > _maxLength) {
+      return false;
+    }
+
+    return _namePattern.hasMatch(networkName);
+  }
+
+  static String _truncateNetworkName(String sanitizedBaseName) {
+    final maxBaseLength = _maxLength - _suffix.length;
+    final truncatedBaseName = _trimSeparators(
+      sanitizedBaseName.substring(0, maxBaseLength),
+    );
+
+    if (truncatedBaseName.isEmpty) {
+      return '$_fallbackPrefix$_suffix';
+    }
+
+    return '$truncatedBaseName$_suffix';
+  }
+
+  static String _sanitizeBaseName(String projectName) {
+    var sanitized = projectName.replaceAll(RegExp(r'[^a-zA-Z0-9_.-]'), '-');
+    sanitized = sanitized.replaceAll(RegExp(r'[-_.]{2,}'), '-');
+    sanitized = _trimSeparators(sanitized);
+
+    if (sanitized.isEmpty || !_startsWithAlphanumeric(sanitized)) {
+      sanitized = _trimSeparators(
+        '$_fallbackPrefix${sanitized.isEmpty ? '' : '-$sanitized'}',
+      );
+    }
+
+    if (sanitized.isEmpty) {
+      return _fallbackPrefix;
+    }
+
+    return sanitized;
+  }
+
+  static String _trimSeparators(String value) {
+    return value.replaceAll(RegExp(r'^[-_.]+|[-_.]+$'), '');
+  }
+
+  static bool _startsWithAlphanumeric(String value) {
+    return RegExp(r'^[a-zA-Z0-9]').hasMatch(value);
+  }
+}

--- a/lib/src/template_generator.dart
+++ b/lib/src/template_generator.dart
@@ -6,6 +6,8 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
+import 'docker_network_name.dart';
+
 /// Generator for Serverpod VPS deployment files.
 /// Takes a Serverpod project and adds necessary files for VPS deployment.
 class TemplateGenerator {
@@ -269,19 +271,52 @@ class TemplateGenerator {
     String templatesDir,
     Progress progress,
   ) async {
+    final dockerNetworkNameResult = DockerNetworkName.buildFromProjectName(
+      projectDirectoryName,
+    );
+    _logDockerNetworkNameWarnings(dockerNetworkNameResult);
+
+    final dockerNetworkName = dockerNetworkNameResult.networkName;
+
     // Copy GitHub workflows
     await _copyDirectory(
       source: path.join(templatesDir, 'github', 'workflows'),
       destination: path.join(projectDirectoryPath, '.github', 'workflows'),
       progress: progress,
+      dockerNetworkName: dockerNetworkName,
     );
 
     // Copy server files
-    await _copyServerFiles(templatesDir, progress);
+    await _copyServerFiles(
+      templatesDir,
+      progress,
+      dockerNetworkName: dockerNetworkName,
+    );
+  }
+
+  void _logDockerNetworkNameWarnings(DockerNetworkNameBuildResult result) {
+    if (result.wasSanitized) {
+      _logger.info(
+        'Docker network name sanitized to "${result.networkName}" because '
+        'the project name contains characters that are invalid for Docker '
+        'network names.',
+      );
+    }
+
+    if (result.wasTruncated) {
+      _logger.info(
+        'Docker network name truncated to "${result.networkName}" because '
+        'Docker network names must be 63 characters or fewer.',
+      );
+    }
   }
 
   /// Copy server-specific files
-  Future<void> _copyServerFiles(String templatesDir, Progress progress) async {
+  Future<void> _copyServerFiles(
+    String templatesDir,
+    Progress progress, {
+    required String dockerNetworkName,
+  }) async {
     final serverDestination = path.join(
       projectDirectoryPath,
       '${projectDirectoryName}_server',
@@ -297,6 +332,7 @@ class TemplateGenerator {
         source: serverTemplatesDir,
         destination: serverDestination,
         progress: progress,
+        dockerNetworkName: dockerNetworkName,
       );
     }
 
@@ -310,6 +346,7 @@ class TemplateGenerator {
         source: serverUpgradeTemplatesDir,
         destination: serverDestination,
         progress: progress,
+        dockerNetworkName: dockerNetworkName,
       );
     }
   }
@@ -328,6 +365,7 @@ class TemplateGenerator {
     required String source,
     required String destination,
     required Progress progress,
+    required String dockerNetworkName,
   }) async {
     final sourceDir = Directory(source);
     if (!await sourceDir.exists()) {
@@ -382,8 +420,10 @@ class TemplateGenerator {
 
         // Read file content and replace placeholders
         var content = await entity.readAsString();
+
         content = content
             .replaceAll('{{ACME_EMAIL}}', userEmail)
+            .replaceAll('{{DOCKER_NETWORK_NAME}}', dockerNetworkName)
             .replaceAll('projectname', projectDirectoryName);
 
         // Create parent directories if they don't exist

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serverpod_vps
 description: A CLI tool for generating the required files for a Serverpod VPS deployment
-version: 1.0.5
+version: 1.0.6
 repository: https://github.com/inf0rmatix/serverpod_vps
 homepage: https://github.com/inf0rmatix/serverpod_vps
 documentation: https://github.com/inf0rmatix/serverpod_vps

--- a/test/docker_network_name_test.dart
+++ b/test/docker_network_name_test.dart
@@ -1,0 +1,112 @@
+import 'package:serverpod_vps/serverpod_vps.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DockerNetworkName', () {
+    test(
+        'fromProjectName keeps valid project names and appends -network suffix',
+        () {
+      expect(
+        DockerNetworkName.fromProjectName('my_test_project'),
+        'my_test_project-network',
+      );
+      expect(
+        DockerNetworkName.fromProjectName('demo.project'),
+        'demo.project-network',
+      );
+    });
+
+    test('fromProjectName replaces invalid characters with hyphens', () {
+      expect(
+        DockerNetworkName.fromProjectName('my weird!name'),
+        'my-weird-name-network',
+      );
+      expect(
+        DockerNetworkName.fromProjectName('foo@bar#baz'),
+        'foo-bar-baz-network',
+      );
+    });
+
+    test(
+      'fromProjectName prefixes names that do not start with a letter or digit',
+      () {
+        expect(
+          DockerNetworkName.fromProjectName('---'),
+          'serverpod-network',
+        );
+        expect(
+          DockerNetworkName.fromProjectName('.hidden'),
+          'hidden-network',
+        );
+      },
+    );
+
+    test('fromProjectName truncates names longer than Docker allows', () {
+      final longProjectName = 'a' * 80;
+      final networkName = DockerNetworkName.fromProjectName(longProjectName);
+
+      expect(networkName.length, lessThanOrEqualTo(63));
+      expect(DockerNetworkName.isValid(networkName), isTrue);
+      expect(networkName, endsWith('-network'));
+    });
+
+    test('fromProjectName always returns a valid Docker network name', () {
+      final projectNames = [
+        'my_test_project',
+        'My App',
+        '@weird',
+        '---',
+        'a' * 80,
+        'foo..bar',
+      ];
+
+      for (final projectName in projectNames) {
+        final networkName = DockerNetworkName.fromProjectName(projectName);
+
+        expect(
+          DockerNetworkName.isValid(networkName),
+          isTrue,
+          reason: 'Invalid network name for project "$projectName": '
+              '$networkName',
+        );
+      }
+    });
+
+    test('buildFromProjectName reports sanitization and truncation', () {
+      expect(
+        DockerNetworkName.buildFromProjectName('my_test_project'),
+        (
+          networkName: 'my_test_project-network',
+          wasSanitized: false,
+          wasTruncated: false,
+        ),
+      );
+
+      expect(
+        DockerNetworkName.buildFromProjectName('my weird!name'),
+        (
+          networkName: 'my-weird-name-network',
+          wasSanitized: true,
+          wasTruncated: false,
+        ),
+      );
+
+      final longProjectName = 'a' * 80;
+      final truncatedResult = DockerNetworkName.buildFromProjectName(
+        longProjectName,
+      );
+
+      expect(truncatedResult.wasSanitized, isFalse);
+      expect(truncatedResult.wasTruncated, isTrue);
+      expect(truncatedResult.networkName.length, lessThanOrEqualTo(63));
+
+      final sanitizedAndTruncatedResult =
+          DockerNetworkName.buildFromProjectName(
+        '${'a' * 70} weird!name',
+      );
+
+      expect(sanitizedAndTruncatedResult.wasSanitized, isTrue);
+      expect(sanitizedAndTruncatedResult.wasTruncated, isTrue);
+    });
+  });
+}

--- a/test/template_generator_test.dart
+++ b/test/template_generator_test.dart
@@ -125,9 +125,52 @@ void main() {
           ).readAsStringSync();
 
           expect(composeContent, isNot(contains('projectname')));
+          expect(composeContent, isNot(contains('{{DOCKER_NETWORK_NAME}}')));
           expect(workflowContent, isNot(contains('projectname')));
+          expect(composeContent, isNot(contains('serverpod-network')));
+          expect(composeContent, contains('$testDirName-network'));
           expect(workflowContent, contains('${testDirName}_server'));
           expect(composeContent, contains(testEmail));
+        } finally {
+          Directory.current = originalDir;
+        }
+      },
+    );
+
+    test(
+      'sanitizes docker network names for projects with invalid characters',
+      () async {
+        const testDirName = 'my weird!name';
+        const expectedNetworkName = 'my-weird-name-network';
+
+        final testDir = Directory(path.join(tempDir.path, 'weird_name_project'))
+          ..createSync();
+
+        Directory(path.join(testDir.path, '${testDirName}_server'))
+            .createSync();
+        Directory(path.join(testDir.path, '${testDirName}_client'))
+            .createSync();
+
+        final originalDir = Directory.current;
+        Directory.current = testDir.path;
+
+        try {
+          await generator.generateDeploymentFilesForTesting(
+            email: 'ssl@example.com',
+          );
+
+          final composeContent = File(
+            path.join(
+              testDir.path,
+              '${testDirName}_server',
+              'docker-compose.production.yaml',
+            ),
+          ).readAsStringSync();
+
+          expect(composeContent, contains(expectedNetworkName));
+          expect(composeContent, isNot(contains('{{DOCKER_NETWORK_NAME}}')));
+          expect(composeContent, isNot(contains('$testDirName-network')));
+          expect(DockerNetworkName.isValid(expectedNetworkName), isTrue);
         } finally {
           Directory.current = originalDir;
         }


### PR DESCRIPTION
## Summary
- Replace hardcoded `serverpod-network` with `{{DOCKER_NETWORK_NAME}}` in generated `docker-compose.production.yaml`
- Add `DockerNetworkName` to sanitize project names and enforce Docker's 63-character DNS label limit
- Log info when the network name is sanitized or truncated
- Closes #7

## Migration
Existing deployments must update `docker-compose.production.yaml` to use the new project-specific network name, or re-run `serverpod_vps` to regenerate the file.

## Test plan
- [x] `dart analyze`
- [x] `dart test` (17/17)