### PR TITLE
feat: make generated VPS stacks multi-stack safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 <!-- markdownlint-disable first-line-heading -->
 
+## 1.0.7
+
+- Make generated VPS stacks multi-stack safe on a single host
+- Isolate Traefik per project with `exposedbydefault=false`, `serverpod_vps.instance`, and project-prefixed router/service labels
+- Prompt for Traefik HTTP/HTTPS and Postgres host ports during file generation
+- Warn when a non-standard HTTPS host port is chosen and print DNS challenge steps for Let's Encrypt
+- Document running multiple stacks on one VPS, custom HTTPS ports, and Cloudflare DNS challenge setup for ACME
+- **Note:** Existing deployments should re-run `serverpod_vps` or manually update `docker-compose.production.yaml` for Traefik isolation and port settings
+
 ## 1.0.6
 
 - Use a project-specific Docker network name via the `{{DOCKER_NETWORK_NAME}}` placeholder in generated `docker-compose.production.yaml` instead of the hardcoded `serverpod-network`

--- a/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.md
+++ b/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.md
@@ -216,8 +216,11 @@ By default, there will be two inbound rules: one for SSH (port 22) and one for I
 
 1. Click on **Add Rule**, name it HTTP, set the port to 80, and choose TCP as the protocol.
 2. Click on **Add Rule**, name it HTTPS, set the port to 443, and choose TCP as the protocol.
-3. In the "apply to" section, make sure your server is selected.
-4. Click **Create Firewall**.
+
+If you use custom Traefik host ports for a second stack (for example `8088` and `8443`), add matching firewall rules for those ports as well.
+
+1. In the "apply to" section, make sure your server is selected.
+2. Click **Create Firewall**.
 
 ## Preparing the domain
 
@@ -284,6 +287,7 @@ The following secrets configure Serverpod and the database:
 | SERVERPOD_PASSWORD_EMAIL_SECRET_HASH_PEPPER     | Same value as the `emailSecretHashPepper` key in your local `passwords.yaml` (production) — required when using `serverpod_auth_idp_server` with `JwtConfigFromPasswords()` |
 | SERVERPOD_PASSWORD_JWT_HMAC_SHA512_PRIVATE_KEY  | Same value as the `jwtHmacSha512PrivateKey` key in your local `passwords.yaml` (production) — required when using IdP JWT from passwords |
 | SERVERPOD_PASSWORD_JWT_REFRESH_TOKEN_HASH_PEPPER | Same value as the `jwtRefreshTokenHashPepper` key in your local `passwords.yaml` (production) — required when using IdP JWT from passwords |
+| CF_DNS_API_TOKEN                      | Cloudflare API token for Traefik ACME DNS challenge — **only** when using a non-standard HTTPS host port (see [Let's Encrypt with a custom HTTPS port](#lets-encrypt-with-a-custom-https-port)) |
 
 The production Docker image does not ship `passwords.yaml`. Serverpod reads secret values from environment variables named `SERVERPOD_PASSWORD_<key>`, where `<key>` matches the camelCase key from `passwords.yaml` (for example, `SERVERPOD_PASSWORD_jwtRefreshTokenHashPepper`). The generated workflow and `docker-compose.production.yaml` pass the three IdP/JWT-related keys above from GitHub Actions into the container.
 
@@ -311,7 +315,22 @@ The CLI will generate all necessary deployment files for your project.
    serverpod_vps
    ```
 
-4. When prompted, enter your email address for SSL certificate notifications.
+4. When prompted, enter your email address for SSL certificate notifications and the host ports for Traefik (HTTP/HTTPS) and Postgres. Use the defaults (`80`, `443`, `5432`) for the first stack on a VPS. Choose different ports for additional stacks on the same host.
+
+## Running multiple Serverpod stacks on one VPS
+
+Generated deployment files are isolated per project so multiple Serverpod apps can run on the same VPS:
+
+- **Docker network:** Each project gets its own network name (for example `my_app-network`).
+- **Traefik isolation:** Traefik only discovers containers labeled with a matching `serverpod_vps.instance` value (for example `my_app-vps`).
+- **Router names:** Traefik routers and services are prefixed with the project name (for example `my_app-api`, `my_app-web`).
+- **Host ports:** Each stack needs unique host ports for HTTP, HTTPS, and the local Postgres bind.
+
+When generating files for a second stack on the same VPS, choose unused host ports during the CLI prompts (for example HTTP `8080`, HTTPS `8443`, Postgres `55432`).
+
+If you choose a non-standard HTTPS host port, `serverpod_vps` prints a warning in the terminal. Follow the steps in [Let's Encrypt with a custom HTTPS port](#lets-encrypt-with-a-custom-https-port) so certificate issuance still works.
+
+After generation, verify the `ports` section in `docker-compose.production.yaml` reflects your chosen host bindings.
 
 ## Configuring SSL-certificates
 
@@ -319,10 +338,114 @@ All external connections are secured by Traefik through HTTPS. Traefik uses
 [Let's Encrypt](https://letsencrypt.org/) to automatically generate SSL
 certificates for your domains.
 
+The generated `docker-compose.production.yaml` uses the **TLS-ALPN challenge**
+(`tlschallenge`). That works when Traefik is bound to host port **443** (the
+default from the CLI prompts).
+
 If you need to change the email address that Let's Encrypt uses for certificate
 notifications, edit the email address in the `docker-compose.production.yaml`
 file. Open the file and modify the value of the parameter
 `certificatesresolvers.myresolver.acme.email`.
+
+## Let's Encrypt with a custom HTTPS port
+
+Use this when port `443` is already taken by another stack on the same VPS, or
+when you deliberately map Traefik HTTPS to another host port (for example
+`8443:443`).
+
+```mermaid
+flowchart LR
+  LE["Let's Encrypt"] -->|TLS challenge| P443["Public port 443"]
+  LE -->|DNS challenge| CF["Cloudflare DNS TXT record"]
+  P443 --> T443["Traefik on host 443"]
+  CF --> T8443["Traefik on host 8443"]
+```
+
+**TLS challenge (default):** Let's Encrypt connects to your domain on public port
+`443`. It does **not** follow a Docker mapping like `8443:443`. If Traefik only
+listens on host port `8443`, the default generated config will not obtain
+certificates.
+
+**DNS challenge (custom HTTPS port):** Let's Encrypt verifies domain ownership
+via a DNS TXT record. Traefik can run on any host HTTPS port. This requires your
+domains to be managed in **Cloudflare**.
+
+### 1. Switch Traefik to DNS challenge in `docker-compose.production.yaml`
+
+In the `traefik` service `command` section, replace the TLS challenge lines:
+
+```yaml
+# Remove:
+- "--certificatesresolvers.myresolver.acme.tlschallenge=true"
+
+# Add:
+- "--certificatesresolvers.myresolver.acme.dnschallenge=true"
+- "--certificatesresolvers.myresolver.acme.dnschallenge.provider=cloudflare"
+```
+
+Add the Cloudflare token to the `traefik` service `environment`:
+
+```yaml
+environment:
+  - CF_DNS_API_TOKEN
+```
+
+Example host port mapping for a second stack:
+
+```yaml
+ports:
+  - "8088:80"
+  - "8443:443"
+```
+
+### 2. Add the GitHub secret and deploy env var
+
+| Secret | Purpose |
+| ------ | ------- |
+| `CF_DNS_API_TOKEN` | Cloudflare API token with DNS edit permission for your zone |
+
+In `.github/workflows/deployment-docker.yml`, pass the token into the deploy step
+`env` (alongside your other variables):
+
+```yaml
+CF_DNS_API_TOKEN: ${{ secrets.CF_DNS_API_TOKEN }}
+```
+
+### 3. Align Serverpod public ports with your host binding
+
+The generated workflow sets `SERVERPOD_*_PUBLIC_PORT` to `443`. Change these to
+your HTTPS host port (for example `8443`):
+
+```yaml
+SERVERPOD_API_SERVER_PUBLIC_PORT: 8443
+SERVERPOD_INSIGHTS_SERVER_PUBLIC_PORT: 8443
+SERVERPOD_WEB_SERVER_PUBLIC_PORT: 8443
+```
+
+In `config/production.yaml`, set `publicPort` on all three servers to the same
+value:
+
+```yaml
+apiServer:
+  publicPort: 8443
+insightsServer:
+  publicPort: 8443
+webServer:
+  publicPort: 8443
+```
+
+### 4. Update clients and OAuth redirect URIs
+
+When `publicPort` is not `443`, URLs must include the port explicitly:
+
+- Flutter / client: `https://api.my-domain.com:8443/`
+- OAuth callbacks (example): `https://web.my-domain.com:8443/auth/callback`
+
+### 5. Open the custom ports in your firewall
+
+Add inbound TCP rules for the HTTP and HTTPS host ports you chose (for example
+`8088` and `8443`), in addition to or instead of `80`/`443` depending on your
+setup.
 
 ## Configuring the GitHub-Action
 
@@ -349,8 +472,12 @@ secrets matches the one in your local `passwords.yaml` file for production.
 ## Connecting your Flutter client
 
 To connect with your generated client, use the domain you set up in the DNS.
-Make sure to use HTTPS without any port numbers (e.g.,
-`https://api.my-domain.com`).
+
+- **Standard HTTPS (port 443):** `https://api.my-domain.com`
+- **Custom HTTPS host port:** include the port in the URL, for example
+  `https://api.my-domain.com:8443/` — and match `publicPort` in
+  `production.yaml` and `SERVERPOD_*_PUBLIC_PORT` in the deploy workflow (see
+  [Let's Encrypt with a custom HTTPS port](#lets-encrypt-with-a-custom-https-port)).
 
 ## Connecting to the Database using DBeaver
 
@@ -372,7 +499,7 @@ following example:
 7. Return to the **Main** tab.
 8. Set the following values:
    - **Host:** localhost
-   - **Port:** 5432
+   - **Port:** The Postgres host port from your `docker-compose.production.yaml` (default `5432`, or the value you chose when running `serverpod_vps`)
    - **Database:** The database name you set in the [repository secrets](#adding-the-secrets-to-the-repository)
    - **User name:** The database user you set in the [repository secrets](#adding-the-secrets-to-the-repository)
    - **Password:** The database password you set in the [repository secrets](#adding-the-secrets-to-the-repository)

--- a/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
+++ b/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
@@ -5,14 +5,16 @@ services:
     command:
       - "--api.insecure=true"
       - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.constraints=Label(`serverpod_vps.instance`,`{{TRAEFIK_INSTANCE}}`)"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
       - "--certificatesresolvers.myresolver.acme.email={{ACME_EMAIL}}"
       - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
     ports:
-      - "80:80"
-      - "443:443"
+      - "{{TRAEFIK_HTTP_HOST_PORT}}:80"
+      - "{{TRAEFIK_HTTPS_HOST_PORT}}:443"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "./letsencrypt:/letsencrypt"
@@ -35,7 +37,7 @@ services:
     ports:
       # Bind the Postgres port to localhost only so it isn't exposed externally,
       # while still allowing connections from the host machine.
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:{{POSTGRES_HOST_PORT}}:5432"
     environment:
       - POSTGRES_USER
       - POSTGRES_DB
@@ -87,23 +89,24 @@ services:
       ]
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`${SERVERPOD_API_SERVER_PUBLIC_HOST}`)"
-      - "traefik.http.routers.api.entrypoints=websecure"
-      - "traefik.http.routers.api.service=api-service"
-      - "traefik.http.routers.api.tls.certresolver=myresolver"
-      - "traefik.http.services.api-service.loadbalancer.server.port=${SERVERPOD_API_SERVER_PORT}"
+      - "serverpod_vps.instance={{TRAEFIK_INSTANCE}}"
+      - "traefik.http.routers.projectname-api.rule=Host(`${SERVERPOD_API_SERVER_PUBLIC_HOST}`)"
+      - "traefik.http.routers.projectname-api.entrypoints=websecure"
+      - "traefik.http.routers.projectname-api.service=projectname-api-service"
+      - "traefik.http.routers.projectname-api.tls.certresolver=myresolver"
+      - "traefik.http.services.projectname-api-service.loadbalancer.server.port=${SERVERPOD_API_SERVER_PORT}"
 
-      - "traefik.http.routers.insights.rule=Host(`${SERVERPOD_INSIGHTS_SERVER_PUBLIC_HOST}`)"
-      - "traefik.http.routers.insights.entrypoints=websecure"
-      - "traefik.http.routers.insights.service=insights-service"
-      - "traefik.http.routers.insights.tls.certresolver=myresolver"
-      - "traefik.http.services.insights-service.loadbalancer.server.port=${SERVERPOD_INSIGHTS_SERVER_PORT}"
+      - "traefik.http.routers.projectname-insights.rule=Host(`${SERVERPOD_INSIGHTS_SERVER_PUBLIC_HOST}`)"
+      - "traefik.http.routers.projectname-insights.entrypoints=websecure"
+      - "traefik.http.routers.projectname-insights.service=projectname-insights-service"
+      - "traefik.http.routers.projectname-insights.tls.certresolver=myresolver"
+      - "traefik.http.services.projectname-insights-service.loadbalancer.server.port=${SERVERPOD_INSIGHTS_SERVER_PORT}"
 
-      - "traefik.http.routers.web.rule=Host(`${SERVERPOD_WEB_SERVER_PUBLIC_HOST}`)"
-      - "traefik.http.routers.web.entrypoints=websecure"
-      - "traefik.http.routers.web.service=web-service"
-      - "traefik.http.routers.web.tls.certresolver=myresolver"
-      - "traefik.http.services.web-service.loadbalancer.server.port=${SERVERPOD_WEB_SERVER_PORT}"
+      - "traefik.http.routers.projectname-web.rule=Host(`${SERVERPOD_WEB_SERVER_PUBLIC_HOST}`)"
+      - "traefik.http.routers.projectname-web.entrypoints=websecure"
+      - "traefik.http.routers.projectname-web.service=projectname-web-service"
+      - "traefik.http.routers.projectname-web.tls.certresolver=myresolver"
+      - "traefik.http.services.projectname-web-service.loadbalancer.server.port=${SERVERPOD_WEB_SERVER_PORT}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/lib/serverpod_vps.dart
+++ b/lib/serverpod_vps.dart
@@ -1,2 +1,4 @@
+export 'src/deployment_stack_config.dart';
 export 'src/docker_network_name.dart';
+export 'src/https_port_acme_warning.dart';
 export 'src/template_generator.dart';

--- a/lib/src/deployment_stack_config.dart
+++ b/lib/src/deployment_stack_config.dart
@@ -1,0 +1,66 @@
+import 'docker_network_name.dart';
+
+/// Host port and Traefik isolation settings for a generated VPS stack.
+class DeploymentStackConfig {
+  const DeploymentStackConfig({
+    required this.dockerNetworkName,
+    required this.traefikInstance,
+    required this.traefikHttpHostPort,
+    required this.traefikHttpsHostPort,
+    required this.postgresHostPort,
+  });
+
+  final String dockerNetworkName;
+  final String traefikInstance;
+  final int traefikHttpHostPort;
+  final int traefikHttpsHostPort;
+  final int postgresHostPort;
+
+  /// Builds stack settings from a project directory name.
+  static DeploymentStackConfig fromProjectName(
+    String projectName, {
+    int traefikHttpHostPort = defaultTraefikHttpHostPort,
+    int traefikHttpsHostPort = defaultTraefikHttpsHostPort,
+    int postgresHostPort = defaultPostgresHostPort,
+  }) {
+    final networkResult = DockerNetworkName.buildFromProjectName(projectName);
+    final stackSlug = networkResult.networkName.replaceFirst(
+      RegExp(r'-network$'),
+      '',
+    );
+
+    return DeploymentStackConfig(
+      dockerNetworkName: networkResult.networkName,
+      traefikInstance: '$stackSlug-vps',
+      traefikHttpHostPort: validatePort(
+        traefikHttpHostPort,
+        label: 'Traefik HTTP host port',
+      ),
+      traefikHttpsHostPort: validatePort(
+        traefikHttpsHostPort,
+        label: 'Traefik HTTPS host port',
+      ),
+      postgresHostPort: validatePort(
+        postgresHostPort,
+        label: 'Postgres host port',
+      ),
+    );
+  }
+
+  static const int defaultTraefikHttpHostPort = 80;
+  static const int defaultTraefikHttpsHostPort = 443;
+  static const int defaultPostgresHostPort = 5432;
+
+  /// Validates a TCP/UDP port number for Docker host bindings.
+  static int validatePort(int port, {required String label}) {
+    if (port < 1 || port > 65535) {
+      throw ArgumentError.value(
+        port,
+        'port',
+        '$label must be between 1 and 65535.',
+      );
+    }
+
+    return port;
+  }
+}

--- a/lib/src/https_port_acme_warning.dart
+++ b/lib/src/https_port_acme_warning.dart
@@ -1,0 +1,41 @@
+import 'deployment_stack_config.dart';
+
+/// Warns when a non-standard HTTPS host port breaks the default ACME TLS challenge.
+class HttpsPortAcmeWarning {
+  const HttpsPortAcmeWarning._();
+
+  /// Whether [httpsHostPort] needs manual ACME changes for Let's Encrypt.
+  static bool shouldWarn(int httpsHostPort) {
+    return httpsHostPort != DeploymentStackConfig.defaultTraefikHttpsHostPort;
+  }
+
+  /// Lines shown after port prompts when [httpsHostPort] is not 443.
+  static List<String> warningLines(int httpsHostPort) {
+    return [
+      'Let\'s Encrypt TLS challenge will not work with host port $httpsHostPort.',
+      'Let\'s Encrypt validates on public port 443, not on your mapped host port.',
+      '',
+      'For a custom HTTPS port (for example when 443 is already in use), switch to',
+      'Traefik DNS challenge with Cloudflare — same approach as a multi-stack VPS setup:',
+      '',
+      '1. In docker-compose.production.yaml, replace the TLS challenge:',
+      '   - Remove: --certificatesresolvers.myresolver.acme.tlschallenge=true',
+      '   - Add:',
+      '     --certificatesresolvers.myresolver.acme.dnschallenge=true',
+      '     --certificatesresolvers.myresolver.acme.dnschallenge.provider=cloudflare',
+      '   - Add CF_DNS_API_TOKEN to the traefik service environment',
+      '',
+      '2. Add CF_DNS_API_TOKEN to your GitHub repository secrets',
+      '',
+      '3. Set SERVERPOD_*_PUBLIC_PORT to $httpsHostPort in deployment-docker.yml',
+      '   (the generated workflow still defaults to 443)',
+      '',
+      '4. Set publicPort: $httpsHostPort in config/production.yaml for api,',
+      '   insights, and web servers',
+      '',
+      '5. Use https://your-domain:$httpsHostPort/ in your client and OAuth redirect URIs',
+      '',
+      'Domains must be in Cloudflare for the DNS challenge to work.',
+    ];
+  }
+}

--- a/lib/src/template_generator.dart
+++ b/lib/src/template_generator.dart
@@ -6,7 +6,9 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
+import 'deployment_stack_config.dart';
 import 'docker_network_name.dart';
+import 'https_port_acme_warning.dart';
 
 /// Generator for Serverpod VPS deployment files.
 /// Takes a Serverpod project and adds necessary files for VPS deployment.
@@ -22,6 +24,11 @@ class TemplateGenerator {
 
   /// The email address to use for SSL certificate notifications.
   late final String userEmail;
+
+  /// Host port bindings for the generated stack.
+  late final int traefikHttpHostPort;
+  late final int traefikHttpsHostPort;
+  late final int postgresHostPort;
 
   /// The list of files that have been copied.
   final _copiedFiles = <String>[];
@@ -62,6 +69,20 @@ class TemplateGenerator {
 
       // Get user input
       userEmail = await _promptEmail();
+      traefikHttpHostPort = await _promptPort(
+        label: 'Traefik HTTP host port',
+        defaultValue: DeploymentStackConfig.defaultTraefikHttpHostPort,
+      );
+      traefikHttpsHostPort = await _promptPort(
+        label: 'Traefik HTTPS host port',
+        defaultValue: DeploymentStackConfig.defaultTraefikHttpsHostPort,
+      );
+      postgresHostPort = await _promptPort(
+        label: 'Postgres host port (127.0.0.1 bind)',
+        defaultValue: DeploymentStackConfig.defaultPostgresHostPort,
+      );
+
+      logNonStandardHttpsPortWarningIfNeeded();
 
       // Generate deployment files
       await _generateTemplate();
@@ -129,8 +150,15 @@ class TemplateGenerator {
   @visibleForTesting
   Future<void> generateDeploymentFilesForTesting({
     required String email,
+    int traefikHttpHostPort = DeploymentStackConfig.defaultTraefikHttpHostPort,
+    int traefikHttpsHostPort =
+        DeploymentStackConfig.defaultTraefikHttpsHostPort,
+    int postgresHostPort = DeploymentStackConfig.defaultPostgresHostPort,
   }) async {
     userEmail = email;
+    this.traefikHttpHostPort = traefikHttpHostPort;
+    this.traefikHttpsHostPort = traefikHttpsHostPort;
+    this.postgresHostPort = postgresHostPort;
     _initializeProjectPaths();
 
     final progress = _logger.progress('Generating');
@@ -276,22 +304,44 @@ class TemplateGenerator {
     );
     _logDockerNetworkNameWarnings(dockerNetworkNameResult);
 
-    final dockerNetworkName = dockerNetworkNameResult.networkName;
+    final stackConfig = DeploymentStackConfig.fromProjectName(
+      projectDirectoryName,
+      traefikHttpHostPort: traefikHttpHostPort,
+      traefikHttpsHostPort: traefikHttpsHostPort,
+      postgresHostPort: postgresHostPort,
+    );
 
     // Copy GitHub workflows
     await _copyDirectory(
       source: path.join(templatesDir, 'github', 'workflows'),
       destination: path.join(projectDirectoryPath, '.github', 'workflows'),
       progress: progress,
-      dockerNetworkName: dockerNetworkName,
+      stackConfig: stackConfig,
     );
 
     // Copy server files
     await _copyServerFiles(
       templatesDir,
       progress,
-      dockerNetworkName: dockerNetworkName,
+      stackConfig: stackConfig,
     );
+  }
+
+  @visibleForTesting
+  void logNonStandardHttpsPortWarningIfNeeded() {
+    if (!HttpsPortAcmeWarning.shouldWarn(traefikHttpsHostPort)) {
+      return;
+    }
+
+    _logger.warn(
+      'Non-standard HTTPS host port ($traefikHttpsHostPort): '
+      'manual Let\'s Encrypt changes are required.',
+    );
+
+    for (final line
+        in HttpsPortAcmeWarning.warningLines(traefikHttpsHostPort)) {
+      _logger.info(line);
+    }
   }
 
   void _logDockerNetworkNameWarnings(DockerNetworkNameBuildResult result) {
@@ -315,7 +365,7 @@ class TemplateGenerator {
   Future<void> _copyServerFiles(
     String templatesDir,
     Progress progress, {
-    required String dockerNetworkName,
+    required DeploymentStackConfig stackConfig,
   }) async {
     final serverDestination = path.join(
       projectDirectoryPath,
@@ -332,7 +382,7 @@ class TemplateGenerator {
         source: serverTemplatesDir,
         destination: serverDestination,
         progress: progress,
-        dockerNetworkName: dockerNetworkName,
+        stackConfig: stackConfig,
       );
     }
 
@@ -346,7 +396,7 @@ class TemplateGenerator {
         source: serverUpgradeTemplatesDir,
         destination: serverDestination,
         progress: progress,
-        dockerNetworkName: dockerNetworkName,
+        stackConfig: stackConfig,
       );
     }
   }
@@ -365,7 +415,7 @@ class TemplateGenerator {
     required String source,
     required String destination,
     required Progress progress,
-    required String dockerNetworkName,
+    required DeploymentStackConfig stackConfig,
   }) async {
     final sourceDir = Directory(source);
     if (!await sourceDir.exists()) {
@@ -423,7 +473,23 @@ class TemplateGenerator {
 
         content = content
             .replaceAll('{{ACME_EMAIL}}', userEmail)
-            .replaceAll('{{DOCKER_NETWORK_NAME}}', dockerNetworkName)
+            .replaceAll(
+              '{{DOCKER_NETWORK_NAME}}',
+              stackConfig.dockerNetworkName,
+            )
+            .replaceAll('{{TRAEFIK_INSTANCE}}', stackConfig.traefikInstance)
+            .replaceAll(
+              '{{TRAEFIK_HTTP_HOST_PORT}}',
+              '${stackConfig.traefikHttpHostPort}',
+            )
+            .replaceAll(
+              '{{TRAEFIK_HTTPS_HOST_PORT}}',
+              '${stackConfig.traefikHttpsHostPort}',
+            )
+            .replaceAll(
+              '{{POSTGRES_HOST_PORT}}',
+              '${stackConfig.postgresHostPort}',
+            )
             .replaceAll('projectname', projectDirectoryName);
 
         // Create parent directories if they don't exist
@@ -452,6 +518,31 @@ class TemplateGenerator {
     );
 
     return regex.hasMatch(fileName);
+  }
+
+  Future<int> _promptPort({
+    required String label,
+    required int defaultValue,
+  }) async {
+    while (true) {
+      final input = _logger.prompt(
+        '$label:',
+        defaultValue: '$defaultValue',
+      );
+
+      final port = int.tryParse(input.trim());
+
+      if (port == null) {
+        _logger.err('Please enter a valid port number.');
+        continue;
+      }
+
+      try {
+        return DeploymentStackConfig.validatePort(port, label: label);
+      } on ArgumentError {
+        _logger.err('Port must be between 1 and 65535.');
+      }
+    }
   }
 
   Future<String> _promptEmail() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serverpod_vps
 description: A CLI tool for generating the required files for a Serverpod VPS deployment
-version: 1.0.6
+version: 1.0.7
 repository: https://github.com/inf0rmatix/serverpod_vps
 homepage: https://github.com/inf0rmatix/serverpod_vps
 documentation: https://github.com/inf0rmatix/serverpod_vps

--- a/test/deployment_stack_config_test.dart
+++ b/test/deployment_stack_config_test.dart
@@ -1,0 +1,47 @@
+import 'package:serverpod_vps/serverpod_vps.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DeploymentStackConfig', () {
+    test('fromProjectName derives traefik instance from network slug', () {
+      final config = DeploymentStackConfig.fromProjectName('my_test_project');
+
+      expect(config.dockerNetworkName, 'my_test_project-network');
+      expect(config.traefikInstance, 'my_test_project-vps');
+      expect(config.traefikHttpHostPort, 80);
+      expect(config.traefikHttpsHostPort, 443);
+      expect(config.postgresHostPort, 5432);
+    });
+
+    test('fromProjectName sanitizes traefik instance like network names', () {
+      final config = DeploymentStackConfig.fromProjectName('my weird!name');
+
+      expect(config.dockerNetworkName, 'my-weird-name-network');
+      expect(config.traefikInstance, 'my-weird-name-vps');
+    });
+
+    test('fromProjectName accepts custom host ports', () {
+      final config = DeploymentStackConfig.fromProjectName(
+        'demo_project',
+        traefikHttpHostPort: 8080,
+        traefikHttpsHostPort: 8443,
+        postgresHostPort: 55432,
+      );
+
+      expect(config.traefikHttpHostPort, 8080);
+      expect(config.traefikHttpsHostPort, 8443);
+      expect(config.postgresHostPort, 55432);
+    });
+
+    test('validatePort rejects invalid port numbers', () {
+      expect(
+        () => DeploymentStackConfig.validatePort(0, label: 'HTTP'),
+        throwsArgumentError,
+      );
+      expect(
+        () => DeploymentStackConfig.validatePort(70000, label: 'HTTPS'),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/https_port_acme_warning_test.dart
+++ b/test/https_port_acme_warning_test.dart
@@ -1,0 +1,30 @@
+import 'package:serverpod_vps/serverpod_vps.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HttpsPortAcmeWarning', () {
+    test('shouldWarn is false for the default HTTPS port', () {
+      expect(
+        HttpsPortAcmeWarning.shouldWarn(
+          DeploymentStackConfig.defaultTraefikHttpsHostPort,
+        ),
+        isFalse,
+      );
+    });
+
+    test('shouldWarn is true for non-standard HTTPS ports', () {
+      expect(HttpsPortAcmeWarning.shouldWarn(8443), isTrue);
+    });
+
+    test('warningLines mention DNS challenge and Cloudflare setup', () {
+      final message = HttpsPortAcmeWarning.warningLines(8443).join('\n');
+
+      expect(message, contains('8443'));
+      expect(message, contains('dnschallenge=true'));
+      expect(message, contains('cloudflare'));
+      expect(message, contains('CF_DNS_API_TOKEN'));
+      expect(message, contains('publicPort: 8443'));
+      expect(message, contains('SERVERPOD_*_PUBLIC_PORT'));
+    });
+  });
+}

--- a/test/template_generator_test.dart
+++ b/test/template_generator_test.dart
@@ -88,6 +88,81 @@ void main() {
     });
 
     test(
+      'generates multi-stack safe traefik and port settings in compose file',
+      () async {
+        const testDirName = 'stack_safe_project';
+        const testEmail = 'ssl@example.com';
+
+        final testDir = Directory(path.join(tempDir.path, testDirName))
+          ..createSync();
+
+        Directory(path.join(testDir.path, '${testDirName}_server'))
+            .createSync();
+        Directory(path.join(testDir.path, '${testDirName}_client'))
+            .createSync();
+
+        final originalDir = Directory.current;
+        Directory.current = testDir.path;
+
+        try {
+          await generator.generateDeploymentFilesForTesting(
+            email: testEmail,
+            traefikHttpHostPort: 8080,
+            traefikHttpsHostPort: 8443,
+            postgresHostPort: 55432,
+          );
+
+          final composeContent = File(
+            path.join(
+              testDir.path,
+              '${testDirName}_server',
+              'docker-compose.production.yaml',
+            ),
+          ).readAsStringSync();
+
+          expect(
+            composeContent,
+            contains('providers.docker.exposedbydefault=false'),
+          );
+          expect(
+            composeContent,
+            contains(
+              'providers.docker.constraints=Label(`serverpod_vps.instance`,`$testDirName-vps`)',
+            ),
+          );
+          expect(
+            composeContent,
+            contains('serverpod_vps.instance=$testDirName-vps'),
+          );
+          expect(composeContent, isNot(contains('traefik.instance=')));
+          expect(
+            composeContent,
+            contains('traefik.http.routers.$testDirName-api.rule'),
+          );
+          expect(
+            composeContent,
+            contains('traefik.http.routers.$testDirName-web.rule'),
+          );
+          expect(
+            composeContent,
+            contains('traefik.http.routers.$testDirName-insights.rule'),
+          );
+          expect(
+            composeContent,
+            isNot(contains('traefik.http.routers.api.rule')),
+          );
+          expect(composeContent, contains('"8080:80"'));
+          expect(composeContent, contains('"8443:443"'));
+          expect(composeContent, contains('127.0.0.1:55432:5432'));
+          expect(composeContent, isNot(contains('{{TRAEFIK_INSTANCE}}')));
+          expect(composeContent, isNot(contains('{{TRAEFIK_HTTP_HOST_PORT}}')));
+        } finally {
+          Directory.current = originalDir;
+        }
+      },
+    );
+
+    test(
       'replaces projectname and email placeholders in generated files',
       () async {
         const testDirName = 'placeholder_test_project';


### PR DESCRIPTION
## Summary
- isolate generated Traefik stacks with exposed-by-default disabled and a non-reserved serverpod_vps.instance constraint label
- prefix generated Traefik router/service names and prompt for Traefik/Postgres host ports
- document multi-stack VPS setup, custom HTTPS ports, and DNS-challenge requirements

Closes #8.

## Validation
- dart analyze
- dart test