### PR TITLE
[codex] Fix Serverpod deployment template updates

### DIFF
--- a/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.yml
+++ b/lib/assets/templates/serverpod_templates/github/workflows/deployment-docker.yml
@@ -56,7 +56,7 @@ jobs:
           build-args: |
             GITHUB_PAT=${{ secrets.PAT_GITHUB }}
             GITHUB_USER=${{ secrets.PAT_USER_GITHUB }}
-          context: ./projectname_server
+          context: .
           file: ./projectname_server/Dockerfile.prod
           push: true
           # TODO This same value is used in docker-compose.production.yaml too,

--- a/lib/assets/templates/serverpod_templates/projectname_server/Dockerfile.prod
+++ b/lib/assets/templates/serverpod_templates/projectname_server/Dockerfile.prod
@@ -1,4 +1,39 @@
-FROM dart:stable AS build
+# Build from the project root with:
+# docker build -f projectname_server/Dockerfile.prod .
+
+FROM ghcr.io/cirruslabs/flutter:stable AS flutter_build
+
+# Accept the GITHUB_PAT and GITHUB_USER as an argument
+ARG GITHUB_PAT
+ARG GITHUB_USER
+
+WORKDIR /app
+COPY . .
+
+RUN if [ -n "$GITHUB_PAT" ] && [ -n "$GITHUB_USER" ]; then \
+    echo "Configuring Git to use provided GitHub token..."; \
+    mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts; \
+    git config --global credential.helper 'store'; \
+    echo "url=https://github.com/.insteadOf git://github.com/" >> ~/.gitconfig; \
+    echo "https://$GITHUB_USER:$GITHUB_PAT@github.com" > ~/.git-credentials; \
+    else \
+    echo "No GitHub token provided. Skipping Git configuration..."; \
+    fi
+
+RUN if [ -d projectname_client ] && [ -d projectname_flutter ]; then \
+    cd projectname_client && dart pub get; \
+    cd ../projectname_flutter && flutter pub get; \
+    flutter build web --release --base-href /app/; \
+    mkdir -p /app/flutter_web; \
+    cp -R build/web/. /app/flutter_web/; \
+    else \
+    echo "No Flutter web app found. Skipping Flutter web build."; \
+    mkdir -p /app/flutter_web; \
+    touch /app/flutter_web/.serverpod_vps_no_flutter_web; \
+    fi
+
+# Build stage
+FROM dart:3.10.3 AS build
 
 # Accept the GITHUB_PAT and GITHUB_USER as an argument
 ARG GITHUB_PAT
@@ -19,21 +54,44 @@ RUN if [ -n "$GITHUB_PAT" ] && [ -n "$GITHUB_USER" ]; then \
     echo "No GitHub token provided. Skipping Git configuration..."; \
     fi
 
+WORKDIR /app/projectname_server
 RUN dart pub get
-RUN dart compile exe bin/main.dart -o bin/server
 
+# Compile the server executable.
+RUN dart build cli --target bin/main.dart --output build
+RUN mv build/bundle/bin/main build/bundle/bin/server
+
+# Add a fallback for the copy of possibly missing directories.
+RUN mkdir -p config web migrations
+COPY --from=flutter_build /app/flutter_web web/app
+RUN if [ -f web/app/.serverpod_vps_no_flutter_web ]; then rm -rf web/app; fi
+
+# Final stage
 FROM alpine:latest
+WORKDIR /app
 
-# Correcting the source directory for runtime dependencies
+# Environment variables
+ENV runmode=production
+ENV serverid=default
+ENV logging=normal
+ENV role=monolith
+
+# Copy runtime dependencies
 COPY --from=build /runtime/ /
-COPY --from=build /app/bin/server server
-COPY --from=build /app/config/ config/
-COPY --from=build /app/web/ web/
-COPY --from=build /app/migrations/ migrations/
+
+# Copy compiled server executable and native libraries
+COPY --from=build /app/projectname_server/build/bundle/ ./
+
+# Copy configuration files and resources
+COPY --from=build /app/projectname_server/config/ config/
+COPY --from=build /app/projectname_server/web/ web/
+COPY --from=build /app/projectname_server/migrations/ migrations/
+
+# This file is required to enable the endpoint log filter in Insights.
+COPY --from=build /app/projectname_server/lib/src/generated/protocol.yaml lib/src/generated/protocol.yaml
 
 EXPOSE 8080
 EXPOSE 8081
 EXPOSE 8082
 
-ENTRYPOINT ["/server"]
-CMD ["--mode", "production", "--server-id", "default", "--logging", "normal", "--role", "monolith"]
+ENTRYPOINT ./bin/server --mode=$runmode --server-id=$serverid --logging=$logging --role=$role

--- a/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
+++ b/lib/assets/templates/serverpod_templates/projectname_server_upgrade/docker-compose.production.yaml
@@ -31,7 +31,7 @@ services:
       timeout: 5s
       retries: 5
     restart: on-failure
-    image: postgres:17
+    image: {{POSTGRES_IMAGE}}
     labels:
       - "traefik.enable=false" # We typically don't expose databases via HTTP.
     ports:

--- a/lib/src/deployment_stack_config.dart
+++ b/lib/src/deployment_stack_config.dart
@@ -8,6 +8,7 @@ class DeploymentStackConfig {
     required this.traefikHttpHostPort,
     required this.traefikHttpsHostPort,
     required this.postgresHostPort,
+    required this.postgresImage,
   });
 
   final String dockerNetworkName;
@@ -15,6 +16,7 @@ class DeploymentStackConfig {
   final int traefikHttpHostPort;
   final int traefikHttpsHostPort;
   final int postgresHostPort;
+  final String postgresImage;
 
   /// Builds stack settings from a project directory name.
   static DeploymentStackConfig fromProjectName(
@@ -22,6 +24,7 @@ class DeploymentStackConfig {
     int traefikHttpHostPort = defaultTraefikHttpHostPort,
     int traefikHttpsHostPort = defaultTraefikHttpsHostPort,
     int postgresHostPort = defaultPostgresHostPort,
+    String postgresImage = defaultPostgresImage,
   }) {
     final networkResult = DockerNetworkName.buildFromProjectName(projectName);
     final stackSlug = networkResult.networkName.replaceFirst(
@@ -44,12 +47,14 @@ class DeploymentStackConfig {
         postgresHostPort,
         label: 'Postgres host port',
       ),
+      postgresImage: postgresImage,
     );
   }
 
   static const int defaultTraefikHttpHostPort = 80;
   static const int defaultTraefikHttpsHostPort = 443;
   static const int defaultPostgresHostPort = 5432;
+  static const String defaultPostgresImage = 'pgvector/pgvector:pg16';
 
   /// Validates a TCP/UDP port number for Docker host bindings.
   static int validatePort(int port, {required String label}) {

--- a/lib/src/template_generator.dart
+++ b/lib/src/template_generator.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart';
 
 import 'deployment_stack_config.dart';
 import 'docker_network_name.dart';
@@ -309,6 +310,7 @@ class TemplateGenerator {
       traefikHttpHostPort: traefikHttpHostPort,
       traefikHttpsHostPort: traefikHttpsHostPort,
       postgresHostPort: postgresHostPort,
+      postgresImage: await detectPostgresImage(),
     );
 
     // Copy GitHub workflows
@@ -359,6 +361,54 @@ class TemplateGenerator {
         'Docker network names must be 63 characters or fewer.',
       );
     }
+  }
+
+  @visibleForTesting
+  Future<String> detectPostgresImage() async {
+    final composeFile = File(
+      path.join(
+        projectDirectoryPath,
+        '${projectDirectoryName}_server',
+        'docker-compose.yaml',
+      ),
+    );
+
+    if (!await composeFile.exists()) {
+      return DeploymentStackConfig.defaultPostgresImage;
+    }
+
+    final composeContent = await composeFile.readAsString();
+
+    return detectPostgresImageFromComposeContent(composeContent);
+  }
+
+  @visibleForTesting
+  String detectPostgresImageFromComposeContent(String composeContent) {
+    final document = loadYaml(composeContent);
+
+    if (document is! YamlMap) {
+      return DeploymentStackConfig.defaultPostgresImage;
+    }
+
+    final services = document['services'];
+
+    if (services is! YamlMap) {
+      return DeploymentStackConfig.defaultPostgresImage;
+    }
+
+    final postgres = services['postgres'];
+
+    if (postgres is! YamlMap) {
+      return DeploymentStackConfig.defaultPostgresImage;
+    }
+
+    final image = postgres['image'];
+
+    if (image is! String || image.isEmpty) {
+      return DeploymentStackConfig.defaultPostgresImage;
+    }
+
+    return image;
   }
 
   /// Copy server-specific files
@@ -472,6 +522,7 @@ class TemplateGenerator {
         var content = await entity.readAsString();
 
         content = content
+            .replaceAll('projectname', projectDirectoryName)
             .replaceAll('{{ACME_EMAIL}}', userEmail)
             .replaceAll(
               '{{DOCKER_NETWORK_NAME}}',
@@ -490,7 +541,7 @@ class TemplateGenerator {
               '{{POSTGRES_HOST_PORT}}',
               '${stackConfig.postgresHostPort}',
             )
-            .replaceAll('projectname', projectDirectoryName);
+            .replaceAll('{{POSTGRES_IMAGE}}', stackConfig.postgresImage);
 
         // Create parent directories if they don't exist
         await Directory(path.dirname(destPath)).create(recursive: true);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   path: ^1.9.1
   mason_logger: ^0.3.2
   meta: ^1.16.0
+  yaml: ^3.1.3
 
 dev_dependencies:
   lints: ^5.1.1

--- a/test/template_generator_test.dart
+++ b/test/template_generator_test.dart
@@ -163,6 +163,161 @@ void main() {
     );
 
     test(
+      'uses postgres image from existing docker compose file',
+      () async {
+        const testDirName = 'postgres_image_project';
+        const testEmail = 'ssl@example.com';
+        const postgresImage = 'postgis/postgis:16-3.4';
+
+        final testDir = Directory(path.join(tempDir.path, testDirName))
+          ..createSync();
+
+        final serverDir = Directory(
+          path.join(testDir.path, '${testDirName}_server'),
+        )..createSync();
+        Directory(path.join(testDir.path, '${testDirName}_client'))
+            .createSync();
+
+        File(path.join(serverDir.path, 'docker-compose.yaml'))
+            .writeAsStringSync('''
+services:
+  postgres:
+    image: $postgresImage
+    ports:
+      - "8090:5432"
+''');
+
+        final originalDir = Directory.current;
+        Directory.current = testDir.path;
+
+        try {
+          await generator.generateDeploymentFilesForTesting(email: testEmail);
+
+          final composeContent = File(
+            path.join(
+              testDir.path,
+              '${testDirName}_server',
+              'docker-compose.production.yaml',
+            ),
+          ).readAsStringSync();
+
+          expect(composeContent, contains('image: $postgresImage'));
+          expect(composeContent, isNot(contains('{{POSTGRES_IMAGE}}')));
+          expect(composeContent, isNot(contains('image: postgres:17')));
+        } finally {
+          Directory.current = originalDir;
+        }
+      },
+    );
+
+    test(
+      'does not replace projectname inside detected postgres image',
+      () async {
+        const testDirName = 'literal_replacement_project';
+        const testEmail = 'ssl@example.com';
+        const postgresImage = 'ghcr.io/acme/projectname-postgres:16';
+
+        final testDir = Directory(path.join(tempDir.path, testDirName))
+          ..createSync();
+
+        final serverDir = Directory(
+          path.join(testDir.path, '${testDirName}_server'),
+        )..createSync();
+        Directory(path.join(testDir.path, '${testDirName}_client'))
+            .createSync();
+
+        File(path.join(serverDir.path, 'docker-compose.yaml'))
+            .writeAsStringSync('''
+services:
+  postgres:
+    image: $postgresImage
+''');
+
+        final originalDir = Directory.current;
+        Directory.current = testDir.path;
+
+        try {
+          await generator.generateDeploymentFilesForTesting(email: testEmail);
+
+          final composeContent = File(
+            path.join(
+              testDir.path,
+              '${testDirName}_server',
+              'docker-compose.production.yaml',
+            ),
+          ).readAsStringSync();
+
+          expect(composeContent, contains('image: $postgresImage'));
+          expect(
+            composeContent,
+            isNot(contains('ghcr.io/acme/$testDirName-postgres:16')),
+          );
+        } finally {
+          Directory.current = originalDir;
+        }
+      },
+    );
+
+    test(
+      'defaults to current Serverpod postgres image when compose is missing',
+      () async {
+        const testDirName = 'default_postgres_image_project';
+        const testEmail = 'ssl@example.com';
+
+        final testDir = Directory(path.join(tempDir.path, testDirName))
+          ..createSync();
+
+        Directory(path.join(testDir.path, '${testDirName}_server'))
+            .createSync();
+        Directory(path.join(testDir.path, '${testDirName}_client'))
+            .createSync();
+
+        final originalDir = Directory.current;
+        Directory.current = testDir.path;
+
+        try {
+          await generator.generateDeploymentFilesForTesting(email: testEmail);
+
+          final composeContent = File(
+            path.join(
+              testDir.path,
+              '${testDirName}_server',
+              'docker-compose.production.yaml',
+            ),
+          ).readAsStringSync();
+
+          expect(
+            composeContent,
+            contains(
+              'image: ${DeploymentStackConfig.defaultPostgresImage}',
+            ),
+          );
+        } finally {
+          Directory.current = originalDir;
+        }
+      },
+    );
+
+    test(
+      'detects postgres image from compose content',
+      () {
+        const composeContent = '''
+services:
+  postgres_test:
+    image: postgres:15
+  postgres:
+    image: "pgvector/pgvector:pg16"
+''';
+
+        final postgresImage = generator.detectPostgresImageFromComposeContent(
+          composeContent,
+        );
+
+        expect(postgresImage, equals('pgvector/pgvector:pg16'));
+      },
+    );
+
+    test(
       'replaces projectname and email placeholders in generated files',
       () async {
         const testDirName = 'placeholder_test_project';
@@ -458,6 +613,60 @@ void main() {
 
     test('builds Docker image for linux/arm64', () {
       expect(workflowTemplate, contains('platforms: linux/arm64'));
+    });
+
+    test('builds Docker image from project root context', () {
+      expect(workflowTemplate, contains('context: .'));
+      expect(
+        workflowTemplate,
+        contains('file: ./projectname_server/Dockerfile.prod'),
+      );
+      expect(
+        workflowTemplate,
+        isNot(contains('context: ./projectname_server')),
+      );
+    });
+  });
+
+  group('production Dockerfile template', () {
+    late String dockerfileTemplate;
+
+    setUp(() {
+      dockerfileTemplate = File(
+        path.join(
+          Directory.current.path,
+          'lib',
+          'assets',
+          'templates',
+          'serverpod_templates',
+          'projectname_server',
+          'Dockerfile.prod',
+        ),
+      ).readAsStringSync();
+    });
+
+    test('builds and copies Flutter web app into server web app directory', () {
+      expect(
+        dockerfileTemplate,
+        contains('flutter build web --release --base-href /app/'),
+      );
+      expect(dockerfileTemplate, contains('/app/flutter_web'));
+      expect(dockerfileTemplate, contains('web/app'));
+    });
+
+    test('uses current Serverpod server build bundle layout', () {
+      expect(dockerfileTemplate, contains('dart build cli'));
+      expect(
+        dockerfileTemplate,
+        contains('WORKDIR /app/projectname_server\nRUN dart pub get'),
+      );
+      expect(
+        dockerfileTemplate,
+        contains(
+          'lib/src/generated/protocol.yaml lib/src/generated/protocol.yaml',
+        ),
+      );
+      expect(dockerfileTemplate, contains('ENTRYPOINT ./bin/server'));
     });
   });
 }


### PR DESCRIPTION
## Summary

- Detect the Postgres image from the existing Serverpod `docker-compose.yaml` and reuse it in `docker-compose.production.yaml`.
- Default new generated production compose files to Serverpod's current `pgvector/pgvector:pg16` image when no source compose image can be detected.
- Update the production Dockerfile template to use the current Serverpod server build bundle layout and include Flutter web output under `web/app` when a Flutter app is present.
- Build the GitHub Actions Docker image from the project root so the Dockerfile can access the server, client, and Flutter app directories.

## Why

Issue #5 tracks a mismatch between this package's production templates and current Serverpod project templates, especially the Postgres image changing from the plain `postgres` image to `pgvector/pgvector:pg16`.

## Validation

- `dart format`
- `dart fix --apply` for modified Dart files
- `dart analyze`
- `dart test`
- `git diff --check`
- Generated deployment files into a disposable Serverpod project
- Built the generated production Docker image with `docker build -f issue5build_server/Dockerfile.prod -t serverpod-vps-issue5-build-check .`
- Verified the built image contains `bin/server`, `web/app/index.html`, and `lib/src/generated/protocol.yaml`

Fixes #5